### PR TITLE
refactor: use `mph` to avoid exit-time destructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       security-events: write

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     name: Build and analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,17 @@ option(WITH_TESTING "Whether to enable tests" ON)
 option(WITH_EXAMPLES "Whether to enable examples" ON)
 option(INSTALL_RESOURCE_DETECTORS "Whether to install Resource Detectors" ON)
 
+include(FetchContent)
+
 find_package(opentelemetry-cpp CONFIG REQUIRED)
+
+FetchContent_Declare(
+    qlibs_mph
+    GIT_REPOSITORY https://github.com/qlibs/mph
+    GIT_TAG v5.0.2
+)
+
+FetchContent_MakeAvailable(qlibs_mph)
 
 add_library(utils OBJECT)
 target_sources(
@@ -31,13 +41,19 @@ target_sources(
 set_target_properties(
     utils
     PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
         POSITION_INDEPENDENT_CODE ON
 )
 
-target_link_libraries(utils PUBLIC opentelemetry-cpp::resources)
+target_link_libraries(
+    utils
+    PUBLIC opentelemetry-cpp::resources
+    PRIVATE qlibs_mph
+)
+
+target_include_directories(utils PUBLIC ${qlibs_mph_SOURCE_DIR})
 
 add_library(helpers STATIC $<TARGET_OBJECTS:utils>)
 target_include_directories(helpers PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/os_utils.cpp
+++ b/src/os_utils.cpp
@@ -4,64 +4,82 @@
 #include <string_view>
 #include <utility>
 
-#include <mph>
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ && __cplusplus >= 202002L
+#    include <mph>
+#    define USE_MPH
+#    define CONTAINER           std::array
+#    define CONTAINER_CONSTEXPR constexpr
+#else
+#    include <unordered_map>
+#    define CONTAINER           std::unordered_map
+#    define CONTAINER_CONSTEXPR const
+#endif
+
 #include <opentelemetry/sdk/resource/semantic_conventions.h>
 
 using std::literals::operator""sv;
 
-namespace {
-
-constexpr auto machine_to_arch = std::array{
-    std::pair{"x86_64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-    std::pair{"amd64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-    std::pair{"aarch64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-    std::pair{"arm64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-    std::pair{"arm"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-    std::pair{"armv7l"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-    std::pair{"ppc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32},
-    std::pair{"ppc64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-    std::pair{"ppc64le"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-    std::pair{"s390x"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x},
-    std::pair{"i386"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"i486"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"i586"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"i686"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"x86"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"i86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"x86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-    std::pair{"ia64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64}
-};
-
-constexpr auto os_to_type = std::array{
-    std::pair{"Linux"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux},
-    std::pair{"Windows_NT"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-    std::pair{"DragonFly"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd},
-    std::pair{"FreeBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd},
-    std::pair{"HP-UX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux},
-    std::pair{"AIX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix},
-    std::pair{"Darwin"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin},
-    std::pair{"NetBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd},
-    std::pair{"OpenBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd},
-    std::pair{"SunOS"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris},
-    std::pair{"OS/390"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs}
-};
-
-}  // namespace
-
 std::string get_host_arch(std::string_view machine)
 {
+    static CONTAINER_CONSTEXPR auto machine_to_arch = CONTAINER{
+        std::pair{"x86_64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
+        std::pair{"amd64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
+        std::pair{"aarch64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
+        std::pair{"arm64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
+        std::pair{"arm"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
+        std::pair{"armv7l"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
+        std::pair{"ppc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32},
+        std::pair{"ppc64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
+        std::pair{"ppc64le"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
+        std::pair{"s390x"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x},
+        std::pair{"i386"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"i486"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"i586"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"i686"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"x86"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"i86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"x86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+        std::pair{"ia64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64}
+    };
+
+#ifdef USE_MPH
     if (const auto arch = mph::find<machine_to_arch>(machine); arch) {
         return arch.value;
     }
+#else
+    if (const auto it = machine_to_arch.find(machine); it != machine_to_arch.end()) {
+        return it->second;
+    }
+#endif
 
     return {machine.data(), machine.length()};
 }
 
 std::string get_os_type(std::string_view os)
 {
+    static CONTAINER_CONSTEXPR auto os_to_type = CONTAINER{
+        std::pair{"Linux"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux},
+        std::pair{"Windows_NT"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
+        std::pair{"DragonFly"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd},
+        std::pair{"FreeBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd},
+        std::pair{"HP-UX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux},
+        std::pair{"AIX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix},
+        std::pair{"Darwin"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin},
+        std::pair{"NetBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd},
+        std::pair{"OpenBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd},
+        std::pair{"SunOS"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris},
+        std::pair{"OS/390"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs}
+    };
+
+#ifdef USE_MPH
     if (const auto type = mph::find<os_to_type>(os); type) {
         return type.value;
     }
+#else
+    if (const auto it = os_to_type.find(os); it != os_to_type.end()) {
+        return it->second;
+    }
+#endif
 
     if (os.starts_with("CYGWIN") || os.starts_with("MINGW") || os.starts_with("MSYS")) {
         return opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows;

--- a/src/os_utils.cpp
+++ b/src/os_utils.cpp
@@ -1,34 +1,57 @@
 #include "os_utils.h"
 
-#include <unordered_map>
+#include <array>
+#include <string_view>
+#include <utility>
 
+#include <mph>
 #include <opentelemetry/sdk/resource/semantic_conventions.h>
+
+using std::literals::operator""sv;
+
+namespace {
+
+constexpr auto machine_to_arch = std::array{
+    std::pair{"x86_64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
+    std::pair{"amd64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
+    std::pair{"aarch64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
+    std::pair{"arm64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
+    std::pair{"arm"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
+    std::pair{"armv7l"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
+    std::pair{"ppc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32},
+    std::pair{"ppc64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
+    std::pair{"ppc64le"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
+    std::pair{"s390x"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x},
+    std::pair{"i386"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"i486"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"i586"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"i686"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"x86"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"i86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"x86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
+    std::pair{"ia64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64}
+};
+
+constexpr auto os_to_type = std::array{
+    std::pair{"Linux"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux},
+    std::pair{"Windows_NT"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
+    std::pair{"DragonFly"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd},
+    std::pair{"FreeBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd},
+    std::pair{"HP-UX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux},
+    std::pair{"AIX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix},
+    std::pair{"Darwin"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin},
+    std::pair{"NetBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd},
+    std::pair{"OpenBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd},
+    std::pair{"SunOS"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris},
+    std::pair{"OS/390"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs}
+};
+
+}  // namespace
 
 std::string get_host_arch(std::string_view machine)
 {
-    static const std::unordered_map<std::string_view, const char*> machine_to_arch{
-        {"x86_64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-        {"amd64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-        {"aarch64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-        {"arm64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-        {"arm", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-        {"armv7l", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-        {"ppc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32},
-        {"ppc64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-        {"ppc64le", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-        {"s390x", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x},
-        {"i386", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"i486", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"i586", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"i686", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"x86", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"i86pc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"x86pc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        {"ia64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64}
-    };
-
-    if (const auto it = machine_to_arch.find(machine); it != machine_to_arch.end()) {
-        return it->second;
+    if (const auto arch = mph::find<machine_to_arch>(machine); arch) {
+        return arch.value;
     }
 
     return {machine.data(), machine.length()};
@@ -36,30 +59,12 @@ std::string get_host_arch(std::string_view machine)
 
 std::string get_os_type(std::string_view os)
 {
-    static const std::unordered_map<std::string_view, const char*> os_to_type{
-        {"Linux", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux},
-        {"Windows_NT", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"CYGWIN_NT-5.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"CYGWIN_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"CYGWIN_NT-6.1-WOW64", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"CYGWIN_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"MINGW32_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"MSYS_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"MINGW32_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"MSYS_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        {"DragonFly", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd},
-        {"FreeBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd},
-        {"HP-UX", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux},
-        {"AIX", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix},
-        {"Darwin", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin},
-        {"NetBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd},
-        {"OpenBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd},
-        {"SunOS", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris},
-        {"OS/390", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs}
-    };
+    if (const auto type = mph::find<os_to_type>(os); type) {
+        return type.value;
+    }
 
-    if (const auto it = os_to_type.find(os); it != os_to_type.end()) {
-        return it->second;
+    if (os.starts_with("CYGWIN") || os.starts_with("MINGW") || os.starts_with("MSYS")) {
+        return opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows;
     }
 
     return {os.data(), os.length()};


### PR DESCRIPTION
Ref: https://github.com/qlibs/mph