### PR TITLE
fix: add support for OpenTelemetry 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.cache/
 /.vscode/
 /build*/

--- a/src/container_resource_detector.cpp
+++ b/src/container_resource_detector.cpp
@@ -1,11 +1,16 @@
 #include "opentelemetry/resource/wwa/container_resource_detector.h"
 
 #include <fstream>
-#include <regex>
-#include <stdexcept>
 #include <string>
 
-#include <opentelemetry/sdk/resource/semantic_conventions.h>
+#include <opentelemetry/version.h>
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+#    include <opentelemetry/sdk/resource/semantic_conventions.h>
+#else
+#    include <opentelemetry/semconv/incubating/container_attributes.h>
+#    include <opentelemetry/semconv/schema_url.h>
+#endif
 
 #include "container_utils.h"
 
@@ -31,12 +36,18 @@ namespace wwa::opentelemetry::resource {
         return ::opentelemetry::sdk::resource::Resource::GetEmpty();
     }
 
-    ::opentelemetry::sdk::resource::ResourceAttributes attrs;
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kContainerId] = cid;
+#    if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+    using ::opentelemetry::sdk::resource::SemanticConventions::kContainerId;
+    using ::opentelemetry::sdk::resource::SemanticConventions::kSchemaUrl;
+#    else
+    using ::opentelemetry::semconv::container::kContainerId;
+    using ::opentelemetry::semconv::kSchemaUrl;
+#    endif
 
-    return ::opentelemetry::sdk::resource::Resource::Create(
-        attrs, ::opentelemetry::sdk::resource::SemanticConventions::kSchemaUrl
-    );
+    ::opentelemetry::sdk::resource::ResourceAttributes attrs;
+    attrs[kContainerId] = cid;
+
+    return ::opentelemetry::sdk::resource::Resource::Create(attrs, kSchemaUrl);
 #endif
 }
 

--- a/src/os_resource_detector.cpp
+++ b/src/os_resource_detector.cpp
@@ -13,7 +13,15 @@
 #    include "tstring.h"
 #endif
 
-#include <opentelemetry/sdk/resource/semantic_conventions.h>
+#include <opentelemetry/version.h>
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+#    include <opentelemetry/sdk/resource/semantic_conventions.h>
+#else
+#    include <opentelemetry/semconv/incubating/host_attributes.h>
+#    include <opentelemetry/semconv/incubating/os_attributes.h>
+#    include <opentelemetry/semconv/schema_url.h>
+#endif
 
 #include "os_utils.h"
 
@@ -23,6 +31,20 @@ namespace wwa::opentelemetry::resource {
 {
     ::opentelemetry::sdk::resource::ResourceAttributes attrs;
 
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+    using ::opentelemetry::sdk::resource::SemanticConventions::kHostArch;
+    using ::opentelemetry::sdk::resource::SemanticConventions::kHostName;
+    using ::opentelemetry::sdk::resource::SemanticConventions::kOsType;
+    using ::opentelemetry::sdk::resource::SemanticConventions::kOsVersion;
+    using ::opentelemetry::sdk::resource::SemanticConventions::kSchemaUrl;
+#else
+    using ::opentelemetry::semconv::host::kHostArch;
+    using ::opentelemetry::semconv::host::kHostName;
+    using ::opentelemetry::semconv::kSchemaUrl;
+    using ::opentelemetry::semconv::os::kOsType;
+    using ::opentelemetry::semconv::os::kOsVersion;
+#endif
+
 #ifndef _WIN32
     utsname info{};
     if (uname(&info) == -1) {
@@ -30,28 +52,25 @@ namespace wwa::opentelemetry::resource {
     }
 
     // NOLINTBEGIN(*-bounds-array-to-pointer-decay) -- we have no control over the system interface
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostArch]  = get_host_arch(info.machine);
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostName]  = std::string(info.nodename);
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kOsType]    = get_os_type(info.sysname);
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kOsVersion] = std::string(info.release);
+    attrs[kHostArch]  = get_host_arch(info.machine);
+    attrs[kHostName]  = std::string(info.nodename);
+    attrs[kOsType]    = get_os_type(info.sysname);
+    attrs[kOsVersion] = std::string(info.release);
     // NOLINTEND(*-bounds-array-to-pointer-decay)
 #else
     SYSTEM_INFO si{};
     GetSystemInfo(&si);
     switch (si.wProcessorArchitecture) {
         case PROCESSOR_ARCHITECTURE_AMD64:
-            attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostArch] =
-                std::string(::opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64);
+            attrs[kHostArch] = std::string(HostArchValues::kAmd64);
             break;
 
         case PROCESSOR_ARCHITECTURE_INTEL:
-            attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostArch] =
-                std::string(::opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86);
+            attrs[kHostArch] = std::string(HostArchValues::kX86);
             break;
 
         case PROCESSOR_ARCHITECTURE_ARM64:
-            attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostArch] =
-                std::string(::opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64);
+            attrs[kHostArch] = std::string(HostArchValues::kArm64);
             break;
 
         default:
@@ -60,28 +79,24 @@ namespace wwa::opentelemetry::resource {
 
     std::array<TCHAR, MAX_COMPUTERNAME_LENGTH + 1> buf;
     if (auto size = static_cast<DWORD>(buf.size()); GetComputerName(buf.data(), &size)) {
-        attrs[::opentelemetry::sdk::resource::SemanticConventions::kHostName] = convert(buf.data());
+        attrs[kHostName] = convert(buf.data());
     }
 
-    attrs[::opentelemetry::sdk::resource::SemanticConventions::kOsType] =
-        std::string(::opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows);
+    attrs[kOsType] = std::string(OsTypeValues::kWindows);
 
     OSVERSIONINFO osvi{};
     osvi.dwOSVersionInfoSize = sizeof(osvi);
     if (GetVersionEx(&osvi)) {
-        attrs[::opentelemetry::sdk::resource::SemanticConventions::kOsVersion] =
-            std::to_string(osvi.dwMajorVersion)
-                .append(".")
-                .append(std::to_string(osvi.dwMinorVersion))
-                .append(" (Build ")
-                .append(std::to_string(osvi.dwBuildNumber))
-                .append(")");
+        attrs[kOsVersion] = std::to_string(osvi.dwMajorVersion)
+                                .append(".")
+                                .append(std::to_string(osvi.dwMinorVersion))
+                                .append(" (Build ")
+                                .append(std::to_string(osvi.dwBuildNumber))
+                                .append(")");
     }
 #endif
 
-    return ::opentelemetry::sdk::resource::Resource::Create(
-        attrs, ::opentelemetry::sdk::resource::SemanticConventions::kSchemaUrl
-    );
+    return ::opentelemetry::sdk::resource::Resource::Create(attrs, kSchemaUrl);
 }
 
 }  // namespace wwa::opentelemetry::resource

--- a/src/os_resource_detector.cpp
+++ b/src/os_resource_detector.cpp
@@ -37,12 +37,18 @@ namespace wwa::opentelemetry::resource {
     using ::opentelemetry::sdk::resource::SemanticConventions::kOsType;
     using ::opentelemetry::sdk::resource::SemanticConventions::kOsVersion;
     using ::opentelemetry::sdk::resource::SemanticConventions::kSchemaUrl;
+
+    using namespace ::opentelemetry::sdk::resource::SemanticConventions::HostArchValues;
+    using namespace ::opentelemetry::sdk::resource::SemanticConventions::OsTypeValues;
 #else
     using ::opentelemetry::semconv::host::kHostArch;
     using ::opentelemetry::semconv::host::kHostName;
     using ::opentelemetry::semconv::kSchemaUrl;
     using ::opentelemetry::semconv::os::kOsType;
     using ::opentelemetry::semconv::os::kOsVersion;
+
+    using namespace ::opentelemetry::semconv::host::HostArchValues;
+    using namespace ::opentelemetry::semconv::os::OsTypeValues;
 #endif
 
 #ifndef _WIN32
@@ -62,15 +68,15 @@ namespace wwa::opentelemetry::resource {
     GetSystemInfo(&si);
     switch (si.wProcessorArchitecture) {
         case PROCESSOR_ARCHITECTURE_AMD64:
-            attrs[kHostArch] = std::string(HostArchValues::kAmd64);
+            attrs[kHostArch] = std::string(kAmd64);
             break;
 
         case PROCESSOR_ARCHITECTURE_INTEL:
-            attrs[kHostArch] = std::string(HostArchValues::kX86);
+            attrs[kHostArch] = std::string(kX86);
             break;
 
         case PROCESSOR_ARCHITECTURE_ARM64:
-            attrs[kHostArch] = std::string(HostArchValues::kArm64);
+            attrs[kHostArch] = std::string(kArm64);
             break;
 
         default:
@@ -82,7 +88,7 @@ namespace wwa::opentelemetry::resource {
         attrs[kHostName] = convert(buf.data());
     }
 
-    attrs[kOsType] = std::string(OsTypeValues::kWindows);
+    attrs[kOsType] = std::string(kWindows);
 
     OSVERSIONINFO osvi{};
     osvi.dwOSVersionInfoSize = sizeof(osvi);

--- a/src/os_utils.cpp
+++ b/src/os_utils.cpp
@@ -1,6 +1,5 @@
 #include "os_utils.h"
 
-#include <array>
 #include <string_view>
 #include <utility>
 
@@ -9,6 +8,7 @@
 #endif
 
 #if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ && __cplusplus >= 202002L && !defined(DISABLE_MPH)
+#    include <array>
 #    include <mph>
 #    define USE_MPH
 #    define CONTAINER           std::array
@@ -19,31 +19,45 @@
 #    define CONTAINER_CONSTEXPR const
 #endif
 
-#include <opentelemetry/sdk/resource/semantic_conventions.h>
+#include <opentelemetry/version.h>
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+#    include <opentelemetry/sdk/resource/semantic_conventions.h>
+#else
+#    include <opentelemetry/semconv/incubating/host_attributes.h>
+#    include <opentelemetry/semconv/incubating/os_attributes.h>
+#    include <opentelemetry/semconv/schema_url.h>
+#endif
 
 using std::literals::operator""sv;
 
 std::string get_host_arch(std::string_view machine)
 {
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+    using namespace ::opentelemetry::sdk::resource::SemanticConventions::HostArchValues;
+#else
+    using namespace ::opentelemetry::semconv::host::HostArchValues;
+#endif
+
     static CONTAINER_CONSTEXPR auto machine_to_arch = CONTAINER{
-        std::pair{"x86_64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-        std::pair{"amd64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64},
-        std::pair{"aarch64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-        std::pair{"arm64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64},
-        std::pair{"arm"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-        std::pair{"armv7l"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32},
-        std::pair{"ppc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32},
-        std::pair{"ppc64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-        std::pair{"ppc64le"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64},
-        std::pair{"s390x"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x},
-        std::pair{"i386"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"i486"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"i586"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"i686"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"x86"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"i86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"x86pc"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86},
-        std::pair{"ia64"sv, opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64}
+        std::pair{"x86_64"sv, kAmd64},
+        std::pair{"amd64"sv, kAmd64},
+        std::pair{"aarch64"sv, kArm64},
+        std::pair{"arm64"sv, kArm64},
+        std::pair{"arm"sv, kArm32},
+        std::pair{"armv7l"sv, kArm32},
+        std::pair{"ppc"sv, kPpc32},
+        std::pair{"ppc64"sv, kPpc64},
+        std::pair{"ppc64le"sv, kPpc64},
+        std::pair{"s390x"sv, kS390x},
+        std::pair{"i386"sv, kX86},
+        std::pair{"i486"sv, kX86},
+        std::pair{"i586"sv, kX86},
+        std::pair{"i686"sv, kX86},
+        std::pair{"x86"sv, kX86},
+        std::pair{"i86pc"sv, kX86},
+        std::pair{"x86pc"sv, kX86},
+        std::pair{"ia64"sv, kIa64}
     };
 
 #ifdef USE_MPH
@@ -61,18 +75,24 @@ std::string get_host_arch(std::string_view machine)
 
 std::string get_os_type(std::string_view os)
 {
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+    using namespace ::opentelemetry::sdk::resource::SemanticConventions::OsTypeValues;
+#else
+    using namespace ::opentelemetry::semconv::os::OsTypeValues;
+#endif
+
     static CONTAINER_CONSTEXPR auto os_to_type = CONTAINER{
-        std::pair{"Linux"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux},
-        std::pair{"Windows_NT"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows},
-        std::pair{"DragonFly"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd},
-        std::pair{"FreeBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd},
-        std::pair{"HP-UX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux},
-        std::pair{"AIX"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix},
-        std::pair{"Darwin"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin},
-        std::pair{"NetBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd},
-        std::pair{"OpenBSD"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd},
-        std::pair{"SunOS"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris},
-        std::pair{"OS/390"sv, opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs}
+        std::pair{"Linux"sv, kLinux},
+        std::pair{"Windows_NT"sv, kWindows},
+        std::pair{"DragonFly"sv, kDragonflybsd},
+        std::pair{"FreeBSD"sv, kFreebsd},
+        std::pair{"HP-UX"sv, kHpux},
+        std::pair{"AIX"sv, kAix},
+        std::pair{"Darwin"sv, kDarwin},
+        std::pair{"NetBSD"sv, kNetbsd},
+        std::pair{"OpenBSD"sv, kOpenbsd},
+        std::pair{"SunOS"sv, kSolaris},
+        std::pair{"OS/390"sv, kZOs}
     };
 
 #ifdef USE_MPH
@@ -86,7 +106,7 @@ std::string get_os_type(std::string_view os)
 #endif
 
     if (os.starts_with("CYGWIN") || os.starts_with("MINGW") || os.starts_with("MSYS")) {
-        return opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows;
+        return kWindows;
     }
 
     return {os.data(), os.length()};

--- a/test/os_utils/get_host_arch.cpp
+++ b/test/os_utils/get_host_arch.cpp
@@ -1,11 +1,23 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <opentelemetry/sdk/resource/semantic_conventions.h>
+
+#include <opentelemetry/version.h>
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+#    include <opentelemetry/sdk/resource/semantic_conventions.h>
+#else
+#    include <opentelemetry/semconv/incubating/host_attributes.h>
+#endif
 
 #include "os_utils.h"
 
 class GetHostArchTest : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+using namespace ::opentelemetry::sdk::resource::SemanticConventions::HostArchValues;
+#else
+using namespace ::opentelemetry::semconv::host::HostArchValues;
+#endif
 
 TEST_P(GetHostArchTest, get_host_arch)
 {
@@ -21,24 +33,24 @@ INSTANTIATE_TEST_SUITE_P(
     Table,
     GetHostArchTest,
     testing::Values(
-        std::make_tuple("x86_64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64),
-        std::make_tuple("amd64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kAmd64),
-        std::make_tuple("aarch64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64),
-        std::make_tuple("arm64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm64),
-        std::make_tuple("arm", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32),
-        std::make_tuple("armv7l", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kArm32),
-        std::make_tuple("ppc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc32),
-        std::make_tuple("ppc64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64),
-        std::make_tuple("ppc64le", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kPpc64),
-        std::make_tuple("s390x", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kS390x),
-        std::make_tuple("i386", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("i486", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("i586", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("i686", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("x86", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("i86pc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("x86pc", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kX86),
-        std::make_tuple("ia64", opentelemetry::sdk::resource::SemanticConventions::HostArchValues::kIa64),
+        std::make_tuple("x86_64", kAmd64),
+        std::make_tuple("amd64", kAmd64),
+        std::make_tuple("aarch64", kArm64),
+        std::make_tuple("arm64", kArm64),
+        std::make_tuple("arm", kArm32),
+        std::make_tuple("armv7l", kArm32),
+        std::make_tuple("ppc", kPpc32),
+        std::make_tuple("ppc64", kPpc64),
+        std::make_tuple("ppc64le", kPpc64),
+        std::make_tuple("s390x", kS390x),
+        std::make_tuple("i386", kX86),
+        std::make_tuple("i486", kX86),
+        std::make_tuple("i586", kX86),
+        std::make_tuple("i686", kX86),
+        std::make_tuple("x86", kX86),
+        std::make_tuple("i86pc", kX86),
+        std::make_tuple("x86pc", kX86),
+        std::make_tuple("ia64", kIa64),
         std::make_tuple("UNKNOWN", "UNKNOWN")
     )
 );

--- a/test/os_utils/get_os_type.cpp
+++ b/test/os_utils/get_os_type.cpp
@@ -1,11 +1,24 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <opentelemetry/sdk/resource/semantic_conventions.h>
+
+#include <opentelemetry/version.h>
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+#    include <opentelemetry/sdk/resource/semantic_conventions.h>
+#else
+#    include <opentelemetry/semconv/incubating/os_attributes.h>
+#endif
 
 #include "os_utils.h"
 
 class GetOsTypeTest : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
+
+#if OPENTELEMETRY_VERSION_MAJOR == 1 && OPENTELEMETRY_VERSION_MINOR < 18
+using namespace ::opentelemetry::sdk::resource::SemanticConventions::OsTypeValues;
+#else
+using namespace ::opentelemetry::semconv::os::OsTypeValues;
+#endif
 
 TEST_P(GetOsTypeTest, get_os_type)
 {
@@ -21,27 +34,25 @@ INSTANTIATE_TEST_SUITE_P(
     Table,
     GetOsTypeTest,
     testing::Values(
-        std::make_tuple("Linux", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kLinux),
-        std::make_tuple("Windows_NT", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("CYGWIN_NT-5.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("CYGWIN_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple(
-            "CYGWIN_NT-6.1-WOW64", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows
-        ),
-        std::make_tuple("CYGWIN_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("MINGW32_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("MSYS_NT-6.1", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("MINGW32_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("MSYS_NT-10.0", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kWindows),
-        std::make_tuple("DragonFly", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDragonflybsd),
-        std::make_tuple("FreeBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kFreebsd),
-        std::make_tuple("HP-UX", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kHpux),
-        std::make_tuple("AIX", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kAix),
-        std::make_tuple("Darwin", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kDarwin),
-        std::make_tuple("NetBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kNetbsd),
-        std::make_tuple("OpenBSD", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kOpenbsd),
-        std::make_tuple("SunOS", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kSolaris),
-        std::make_tuple("OS/390", opentelemetry::sdk::resource::SemanticConventions::OsTypeValues::kZOs),
+        std::make_tuple("Linux", kLinux),
+        std::make_tuple("Windows_NT", kWindows),
+        std::make_tuple("CYGWIN_NT-5.1", kWindows),
+        std::make_tuple("CYGWIN_NT-6.1", kWindows),
+        std::make_tuple("CYGWIN_NT-6.1-WOW64", kWindows),
+        std::make_tuple("CYGWIN_NT-10.0", kWindows),
+        std::make_tuple("MINGW32_NT-6.1", kWindows),
+        std::make_tuple("MSYS_NT-6.1", kWindows),
+        std::make_tuple("MINGW32_NT-10.0", kWindows),
+        std::make_tuple("MSYS_NT-10.0", kWindows),
+        std::make_tuple("DragonFly", kDragonflybsd),
+        std::make_tuple("FreeBSD", kFreebsd),
+        std::make_tuple("HP-UX", kHpux),
+        std::make_tuple("AIX", kAix),
+        std::make_tuple("Darwin", kDarwin),
+        std::make_tuple("NetBSD", kNetbsd),
+        std::make_tuple("OpenBSD", kOpenbsd),
+        std::make_tuple("SunOS", kSolaris),
+        std::make_tuple("OS/390", kZOs),
         std::make_tuple("UNKNOWN", "UNKNOWN")
     )
 );


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-cpp/blob/main/DEPRECATED.md#semantic-conventions