### PR TITLE
chore(deps): update default registry's baseline to `86a181505ac6460f98496a79abdee6a0f49905ec`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "0affe8710a4a5b26328e909fe1ad7146df39d108",
+    "baseline": "86a181505ac6460f98496a79abdee6a0f49905ec",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `86a181505ac6460f98496a79abdee6a0f49905ec`.