### PR TITLE
chore(deps): update default registry's baseline to `bea476a80218a581bcb5318595849520217c825e`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "86a181505ac6460f98496a79abdee6a0f49905ec",
+    "baseline": "bea476a80218a581bcb5318595849520217c825e",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `bea476a80218a581bcb5318595849520217c825e`.