### PR TITLE
chore(deps): update default registry's baseline to `3de032f834a9b28a455e35600b03e9d365ce3b85`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "bea476a80218a581bcb5318595849520217c825e",
+    "baseline": "3de032f834a9b28a455e35600b03e9d365ce3b85",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `3de032f834a9b28a455e35600b03e9d365ce3b85`.