### PR TITLE
chore(deps): update default registry's baseline to `6f29f12e82a8293156836ad81cc9bf5af41fe836`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "bea476a80218a581bcb5318595849520217c825e",
+    "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `6f29f12e82a8293156836ad81cc9bf5af41fe836`.