### PR TITLE
chore(deps): update default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
+    "baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`.