### PR TITLE
ci: remove harden-runner

### DIFF
--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -30,11 +30,6 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.triplet }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            github.com:443
-            motd.ubuntu.com:443
-            packages.microsoft.com:443
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,19 +17,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            github.com:443
-            motd.ubuntu.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-
       - name: Check out the source code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,20 +27,6 @@ jobs:
           - c-cpp
           - actions
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            github.com:443
-            motd.ubuntu.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            release-assets.githubusercontent.com:443
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            ghcr.io:443
-            github.com:443
-            pkg-containers.githubusercontent.com:443
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,24 +21,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: block
-          allowed-endpoints:
-            analysis-sensorcache-eu-central-1-prod.s3.amazonaws.com:443
-            api.github.com:443
-            api.nuget.org:443
-            api.sonarcloud.io:443
-            azure.archive.ubuntu.com:80
-            binaries.sonarsource.com:443
-            esm.ubuntu.com:443
-            github.com:443
-            motd.ubuntu.com:443
-            packages.microsoft.com:443
-            scanner.sonarcloud.io:443
-            sonarcloud.io:443
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -16,11 +16,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
This pull request removes the use of the `step-security/harden-runner` action from several GitHub workflow files. This action was previously used to enforce egress policies and other security measures during CI/CD pipeline execution.

### Removal of `step-security/harden-runner`:

* [`.github/workflows/ci-vcpkg.yml`](diffhunk://#diff-f6fdf89697f1e51b8cd66b66f105c01719577f618c15b9293d4bbe53be7ffa3fL33-L37): Removed the `Harden Runner` step, which was configured with an egress policy set to audit.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-L31): Removed the `Harden Runner` step, which enforced an egress policy with a list of allowed endpoints.
* [`.github/workflows/clang-tidy.yml`](diffhunk://#diff-2b7b9696b464e236f8066c1c1d33c6c91c95160f813e2b3fe59ddf0e83057ebfL20-L32): Removed the `Harden Runner` step, which enforced an egress policy with a list of allowed endpoints.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L30-L43): Removed the `Harden Runner` step, which enforced an egress policy with a list of allowed endpoints.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L28-L37): Removed the `Harden Runner` step, which included disabling `sudo` and enforcing an egress policy with a list of allowed endpoints.
* [`.github/workflows/sonarcloud.yml`](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceL24-L41): Removed the `Harden Runner` step, which enforced an egress policy with a list of allowed endpoints specific to SonarCloud analysis.
* [`.github/workflows/update-vcpkg-baseline.yml`](diffhunk://#diff-5634fe56c5352caaba00ac071270d6cd615a63fa007f811b549c5589be6ee81cL19-L23): Removed the `Harden Runner` step, which was configured with an egress policy set to audit.