### PR TITLE
chore(deps): update default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "dd3097e305afa53f7b4312371f62058d2e665320",
+    "baseline": "4334d8b4c8916018600212ab4dd4bbdc343065d1",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`.