### PR TITLE
ci: use clang-format 20 for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,5 +31,5 @@ jobs:
       - name: clang-format Check
         uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
         with:
-          clang-format-version: 18
+          clang-format-version: 20
           check-path: ${{ matrix.path }}


### PR DESCRIPTION
This pull request includes a minor update to the lint workflow configuration, specifically updating the version of `clang-format` used in the CI checks.

- Updated the `clang-format-version` from 18 to 20 in the `.github/workflows/lint.yml` workflow to ensure code formatting checks use the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded code formatting tool version used in the linting workflow to ensure consistent, up-to-date formatting across the codebase.
  * Improved reliability of automated lint checks without altering workflow behavior or app functionality.
  * No impact on end-user features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->