### PR TITLE
chore(deps): update default registry's baseline to `9e593bb18ea69cc5095e012465dcd675a822ed0d`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+    "baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `9e593bb18ea69cc5095e012465dcd675a822ed0d`.